### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -821,14 +821,14 @@ files = [
 ]
 
 [[package]]
-name = "pyautogen"
+name = "ag2"
 version = "0.2.1"
 description = "Enabling Next-Gen LLM Applications via Multi-Agent Conversation Framework"
 optional = false
 python-versions = ">=3.8, <3.12"
 files = [
-    {file = "pyautogen-0.2.1-py3-none-any.whl", hash = "sha256:25fa507efba3c276252fcf01f6ff61439ae5b6b8873b0625585407a7354c78c0"},
-    {file = "pyautogen-0.2.1.tar.gz", hash = "sha256:0071f8f6ee07641330335b2c03c82d9f004061cc7acbc48aba3bb4dfc9a39d87"},
+    {file = "ag2-0.2.1-py3-none-any.whl", hash = "sha256:25fa507efba3c276252fcf01f6ff61439ae5b6b8873b0625585407a7354c78c0"},
+    {file = "ag2-0.2.1.tar.gz", hash = "sha256:0071f8f6ee07641330335b2c03c82d9f004061cc7acbc48aba3bb4dfc9a39d87"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "postgres_da_ai_agent"}]
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
 openai = ">=1.2,<1.3"
-pyautogen = "^0.2.1"
+ag2 = "^0.2.1"
 psycopg2-binary = "^2.9.9"
 argparse = "^1.4.0"
 python-dotenv = "^1.0.0"


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
